### PR TITLE
Validate project paths for scripts

### DIFF
--- a/scripts/audit_autonomous_actions.py
+++ b/scripts/audit_autonomous_actions.py
@@ -140,16 +140,26 @@ class ActionsAuditor:
 
 # --- Main Execution ---
 
-if __name__ == "__main__":
+async def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Audit the autonomous actions for a Roo project to find anomalies."
+        description="Audit the autonomous actions for a Roo project to find anomalies.",
     )
     parser.add_argument(
         "project_name",
         type=str,
-        help="The name of the project directory inside the 'project/' folder."
+        help="The name of the project directory inside the 'project/' folder.",
     )
     args = parser.parse_args()
 
-    auditor = ActionsAuditor(args.project_name)
-    auditor.run_audit()
+    try:
+        project_name = await resolve_project_path(args.project_name)
+    except InvalidProjectPathError as e:
+        print(f"{Colors.FAIL}❌ {e}{Colors.ENDC}")
+        sys.exit(1)
+
+    auditor = ActionsAuditor(project_name)
+    await asyncio.to_thread(auditor.run_audit)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/generate_sprint_report.py
+++ b/scripts/generate_sprint_report.py
@@ -26,7 +26,10 @@ import sys
 import json
 import yaml
 import argparse
+import asyncio
 from datetime import datetime
+
+from path_utils import InvalidProjectPathError, resolve_project_path
 
 # --- ANSI Color Codes for Better Output ---
 class Colors:
@@ -138,16 +141,26 @@ class ReportGenerator:
 
 # --- Main Execution ---
 
-if __name__ == "__main__":
+async def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Generate a sprint progress report for a Roo project."
+        description="Generate a sprint progress report for a Roo project.",
     )
     parser.add_argument(
         "project_name",
         type=str,
-        help="The name of the project directory inside the 'project/' folder."
+        help="The name of the project directory inside the 'project/' folder.",
     )
     args = parser.parse_args()
 
-    reporter = ReportGenerator(args.project_name)
-    reporter.generate_report()
+    try:
+        project_name = await resolve_project_path(args.project_name)
+    except InvalidProjectPathError as e:
+        print(f"{Colors.FAIL}❌ {e}{Colors.ENDC}")
+        sys.exit(1)
+
+    reporter = ReportGenerator(project_name)
+    await asyncio.to_thread(reporter.generate_report)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/path_utils.py
+++ b/scripts/path_utils.py
@@ -1,0 +1,29 @@
+import asyncio
+import os
+from typing import Final
+
+
+class InvalidProjectPathError(Exception):
+    """Raised when the provided project path is invalid."""
+
+
+async def resolve_project_path(project_name: str) -> str:
+    """Sanitize and validate the project name.
+
+    Args:
+        project_name: Raw project name provided by the user.
+
+    Returns:
+        The sanitized project name.
+
+    Raises:
+        InvalidProjectPathError: If the project directory does not exist.
+    """
+    sanitized: Final[str] = os.path.basename(project_name)
+    project_path = os.path.join("project", sanitized)
+    exists = await asyncio.to_thread(os.path.isdir, project_path)
+    if not exists:
+        raise InvalidProjectPathError(
+            f"Project path '{project_path}' does not exist."
+        )
+    return sanitized

--- a/scripts/test_dynamic_delegation.py
+++ b/scripts/test_dynamic_delegation.py
@@ -34,6 +34,9 @@ import time
 import argparse
 import uuid
 import copy
+import asyncio
+
+from path_utils import InvalidProjectPathError, resolve_project_path
 
 # --- ANSI Color Codes for Better Output ---
 class Colors:
@@ -206,19 +209,25 @@ class DelegationTester:
 
 # --- Main Execution ---
 
-if __name__ == "__main__":
+async def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Test the dynamic delegation logic for a Roo project."
+        description="Test the dynamic delegation logic for a Roo project.",
     )
     parser.add_argument(
         "project_name",
         type=str,
-        help="The name of the project directory inside the 'project/' folder."
+        help="The name of the project directory inside the 'project/' folder.",
     )
     args = parser.parse_args()
 
-    tester = DelegationTester(args.project_name)
-    test_passed = tester.run_test()
+    try:
+        project_name = await resolve_project_path(args.project_name)
+    except InvalidProjectPathError as e:
+        print(f"{Colors.FAIL}❌ {e}{Colors.ENDC}")
+        sys.exit(1)
+
+    tester = DelegationTester(project_name)
+    test_passed = await asyncio.to_thread(tester.run_test)
 
     if test_passed:
         print_header("✅ Test Passed ✅")
@@ -228,3 +237,6 @@ if __name__ == "__main__":
         print_header("❌ Test Failed ❌")
         print(f"{Colors.FAIL}The dynamic delegation logic did not perform as expected.{Colors.ENDC}")
         sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/test_quality_intervention.py
+++ b/scripts/test_quality_intervention.py
@@ -34,6 +34,9 @@ import time
 import argparse
 import uuid
 import copy
+import asyncio
+
+from path_utils import InvalidProjectPathError, resolve_project_path
 
 # --- ANSI Color Codes for Better Output ---
 class Colors:
@@ -192,19 +195,25 @@ class QualityInterventionTester:
 
 # --- Main Execution ---
 
-if __name__ == "__main__":
+async def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Test the quality intervention logic for a Roo project."
+        description="Test the quality intervention logic for a Roo project.",
     )
-    parser.add.argument(
+    parser.add_argument(
         "project_name",
         type=str,
-        help="The name of the project directory inside the 'project/' folder."
+        help="The name of the project directory inside the 'project/' folder.",
     )
     args = parser.parse_args()
 
-    tester = QualityInterventionTester(args.project_name)
-    test_passed = tester.run_test()
+    try:
+        project_name = await resolve_project_path(args.project_name)
+    except InvalidProjectPathError as e:
+        print(f"{Colors.FAIL}❌ {e}{Colors.ENDC}")
+        sys.exit(1)
+
+    tester = QualityInterventionTester(project_name)
+    test_passed = await asyncio.to_thread(tester.run_test)
 
     if test_passed:
         print_header("✅ Test Passed ✅")
@@ -214,3 +223,6 @@ if __name__ == "__main__":
         print_header("❌ Test Failed ❌")
         print(f"{Colors.FAIL}The quality intervention logic did not perform as expected.{Colors.ENDC}")
         sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -27,7 +27,10 @@ import sys
 import json
 import yaml
 import argparse
+import asyncio
 from jsonschema import validate, ValidationError
+
+from path_utils import InvalidProjectPathError, resolve_project_path
 
 # --- ANSI Color Codes for Better Output ---
 class Colors:
@@ -240,26 +243,35 @@ class ConfigValidator:
 
 # --- Main Execution ---
 
-if __name__ == "__main__":
+async def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Validate the configuration for a Roo Autonomous AI Framework project."
+        description="Validate the configuration for a Roo Autonomous AI Framework project.",
     )
     parser.add_argument(
         "project_name",
         type=str,
-        help="The name of the project directory inside the 'project/' folder."
+        help="The name of the project directory inside the 'project/' folder.",
     )
     args = parser.parse_args()
 
-    validator = ConfigValidator(args.project_name)
-    is_valid = validator.run_validations()
+    try:
+        project_name = await resolve_project_path(args.project_name)
+    except InvalidProjectPathError as e:
+        print(f"{Colors.FAIL}❌ {e}{Colors.ENDC}")
+        sys.exit(1)
+
+    validator = ConfigValidator(project_name)
+    is_valid = await asyncio.to_thread(validator.run_validations)
 
     if is_valid:
         print_header("✅ Validation Successful ✅")
-        print(f"{Colors.OKGREEN}All configuration files for project '{args.project_name}' are valid.{Colors.ENDC}")
+        print(f"{Colors.OKGREEN}All configuration files for project '{project_name}' are valid.{Colors.ENDC}")
         sys.exit(0)
     else:
         print_header("❌ Validation Failed ❌")
-        print(f"{Colors.FAIL}Found {validator.errors} error(s) in the configuration for project '{args.project_name}'.{Colors.ENDC}")
+        print(f"{Colors.FAIL}Found {validator.errors} error(s) in the configuration for project '{project_name}'.{Colors.ENDC}")
         print(f"{Colors.WARNING}Please fix the issues listed above before starting the autonomous system.{Colors.ENDC}")
         sys.exit(1)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -1,0 +1,28 @@
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure scripts directory is on path
+sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from path_utils import InvalidProjectPathError, resolve_project_path
+
+
+@pytest.mark.asyncio
+async def test_resolve_project_path_valid() -> None:
+    project_name = await resolve_project_path("sample-app")
+    assert project_name == "sample-app"
+
+
+@pytest.mark.asyncio
+async def test_resolve_project_path_sanitizes() -> None:
+    project_name = await resolve_project_path("../sample-app")
+    assert project_name == "sample-app"
+
+
+@pytest.mark.asyncio
+async def test_resolve_project_path_invalid() -> None:
+    with pytest.raises(InvalidProjectPathError):
+        await resolve_project_path("non-existent")


### PR DESCRIPTION
## Summary
- add `resolve_project_path` helper and custom `InvalidProjectPathError`
- sanitize and validate project names in audit, reporting, validation, and test scripts
- cover project path validation with async unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68af05b6e7a88322ba702b2fc6cc42bd