### PR TITLE
Improve script error handling with custom exceptions

### DIFF
--- a/tests/test_audit_exceptions.py
+++ b/tests/test_audit_exceptions.py
@@ -1,0 +1,17 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from audit_autonomous_actions import ActionsAuditor, AuditError
+
+
+def test_run_audit_missing_workflow(tmp_path, monkeypatch) -> None:
+    (tmp_path / "project" / "demo" / "control").mkdir(parents=True)
+    monkeypatch.chdir(tmp_path)
+    auditor = ActionsAuditor("demo")
+    with pytest.raises(AuditError):
+        auditor.run_audit()
+

--- a/tests/test_report_generation_exceptions.py
+++ b/tests/test_report_generation_exceptions.py
@@ -1,0 +1,21 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from generate_sprint_report import ReportGenerator, ReportGenerationError
+
+
+def test_generate_report_missing_file(tmp_path, monkeypatch) -> None:
+    control = tmp_path / "project" / "demo" / "control"
+    control.mkdir(parents=True)
+    (tmp_path / "memory-bank").mkdir()
+    (tmp_path / "memory-bank" / "decisionLog.md").write_text("# log\nentry")
+    (control / "sprint.yaml").write_text("goal: test\n")
+    monkeypatch.chdir(tmp_path)
+    reporter = ReportGenerator("demo")
+    with pytest.raises(ReportGenerationError):
+        reporter.generate_report()
+

--- a/tests/test_validate_config_exceptions.py
+++ b/tests/test_validate_config_exceptions.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from validate_config import ConfigValidator, ConfigValidationError
+
+
+def test_invalid_yaml_raises(tmp_path, monkeypatch) -> None:
+    control = tmp_path / "project" / "demo" / "control"
+    control.mkdir(parents=True)
+    (tmp_path / ".roomodes").write_text("mode\n")
+    (control / "backlog.yaml").write_text("agents: []\n")
+    (control / "sprint.yaml").write_text("invalid: [")
+    (control / "capabilities.yaml").write_text("agents:\n- a\n")
+    (control / "workflow-state.json").write_text("{}")
+    (control / "quality-dashboard.json").write_text("{}")
+    docs = tmp_path / "docs" / "contracts"
+    docs.mkdir(parents=True)
+    (docs / "backlog_v1.schema.json").write_text("{}")
+    (docs / "workflow_state_v2.schema.json").write_text("{}")
+    monkeypatch.chdir(tmp_path)
+    validator = ConfigValidator("demo")
+    with pytest.raises(ConfigValidationError):
+        validator.run_validations()
+


### PR DESCRIPTION
## Summary
- define `AuditError`, `ReportGenerationError`, and `ConfigValidationError` for script-level failures
- wrap file and YAML/JSON operations in try/except and surface meaningful messages
- catch custom exceptions in `__main__` blocks for graceful exits
- add tests verifying exceptions for missing or malformed inputs

## Testing
- `python -m pytest -q`
- `python -m pytest --cov=scripts -q`


------
https://chatgpt.com/codex/tasks/task_e_68af11bd03e48322b353987b07876e75