### PR TITLE
refactor: async file operations

### DIFF
--- a/tests/test_audit_exceptions.py
+++ b/tests/test_audit_exceptions.py
@@ -8,10 +8,11 @@ sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
 from audit_autonomous_actions import ActionsAuditor, AuditError
 
 
-def test_run_audit_missing_workflow(tmp_path, monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_run_audit_missing_workflow(tmp_path, monkeypatch) -> None:
     (tmp_path / "project" / "demo" / "control").mkdir(parents=True)
     monkeypatch.chdir(tmp_path)
     auditor = ActionsAuditor("demo")
     with pytest.raises(AuditError):
-        auditor.run_audit()
+        await auditor.run_audit()
 

--- a/tests/test_report_generation_exceptions.py
+++ b/tests/test_report_generation_exceptions.py
@@ -6,16 +6,20 @@ import pytest
 sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from generate_sprint_report import ReportGenerator, ReportGenerationError
+import aiofiles
 
 
-def test_generate_report_missing_file(tmp_path, monkeypatch) -> None:
+@pytest.mark.asyncio
+async def test_generate_report_missing_file(tmp_path, monkeypatch) -> None:
     control = tmp_path / "project" / "demo" / "control"
     control.mkdir(parents=True)
     (tmp_path / "memory-bank").mkdir()
-    (tmp_path / "memory-bank" / "decisionLog.md").write_text("# log\nentry")
-    (control / "sprint.yaml").write_text("goal: test\n")
+    async with aiofiles.open(tmp_path / "memory-bank" / "decisionLog.md", "w", encoding="utf-8") as f:
+        await f.write("# log\nentry")
+    async with aiofiles.open(control / "sprint.yaml", "w", encoding="utf-8") as f:
+        await f.write("goal: test\n")
     monkeypatch.chdir(tmp_path)
     reporter = ReportGenerator("demo")
     with pytest.raises(ReportGenerationError):
-        reporter.generate_report()
+        await reporter.generate_report()
 


### PR DESCRIPTION
## Summary
- refactor audit and report scripts to async with aiofiles and type hints
- update tests to async style using pytest-asyncio and aiofiles

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68af148b4cc083229977167c0f8ac1e5