### PR TITLE
refactor: centralize console helpers

### DIFF
--- a/scripts/audit_autonomous_actions.py
+++ b/scripts/audit_autonomous_actions.py
@@ -34,28 +34,11 @@ from typing import Any, Dict, List
 import aiofiles
 
 from path_utils import InvalidProjectPathError, resolve_project_path
+from validate_config import Colors, print_header
 
 
 class AuditError(Exception):
     """Raised when an audit operation fails."""
-
-# --- ANSI Color Codes for Better Output ---
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
-
-
-def print_header(message: str) -> None:
-    print(f"\n{Colors.HEADER}{Colors.BOLD}{'=' * 45}{Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}  {message}{Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}{'=' * 45}{Colors.ENDC}")
 
 # --- Auditor Class ---
 

--- a/scripts/generate_sprint_report.py
+++ b/scripts/generate_sprint_report.py
@@ -33,22 +33,11 @@ from typing import Any, Dict
 import aiofiles
 
 from path_utils import InvalidProjectPathError, resolve_project_path
+from validate_config import Colors
 
 
 class ReportGenerationError(Exception):
     """Raised when generating the sprint report fails."""
-
-# --- ANSI Color Codes for Better Output ---
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
 
 # --- Report Generator Class ---
 

--- a/scripts/test_conflict_resolution.py
+++ b/scripts/test_conflict_resolution.py
@@ -38,34 +38,7 @@ import copy
 import asyncio
 
 from path_utils import InvalidProjectPathError, resolve_project_path
-
-# --- ANSI Color Codes for Better Output ---
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\032[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-
-# --- Helper Functions ---
-
-def print_header(message):
-    """Prints a formatted header."""
-    print(f"\n{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}  {message}{Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
-
-def print_status(message, success=True, details=""):
-    """Prints a status message with a checkmark or cross."""
-    if success:
-        print(f"  {Colors.OKGREEN}✅ {message}{Colors.ENDC}")
-    else:
-        print(f"  {Colors.FAIL}❌ {message}{Colors.ENDC}")
-    if details:
-        print(f"     {Colors.OKCYAN}{details}{Colors.ENDC}")
+from validate_config import Colors, print_header, print_status
 
 # --- Test Simulator Class ---
 

--- a/scripts/test_dynamic_delegation.py
+++ b/scripts/test_dynamic_delegation.py
@@ -37,34 +37,7 @@ import copy
 import asyncio
 
 from path_utils import InvalidProjectPathError, resolve_project_path
-
-# --- ANSI Color Codes for Better Output ---
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-
-# --- Helper Functions ---
-
-def print_header(message):
-    """Prints a formatted header."""
-    print(f"\n{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}  {message}{Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
-
-def print_status(message, success=True, details=""):
-    """Prints a status message with a checkmark or cross."""
-    if success:
-        print(f"  {Colors.OKGREEN}✅ {message}{Colors.ENDC}")
-    else:
-        print(f"  {Colors.FAIL}❌ {message}{Colors.ENDC}")
-    if details:
-        print(f"     {Colors.OKCYAN}{details}{Colors.ENDC}")
+from validate_config import Colors, print_header, print_status
 
 # --- Test Simulator Class ---
 

--- a/scripts/test_quality_intervention.py
+++ b/scripts/test_quality_intervention.py
@@ -37,34 +37,7 @@ import copy
 import asyncio
 
 from path_utils import InvalidProjectPathError, resolve_project_path
-
-# --- ANSI Color Codes for Better Output ---
-class Colors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKCYAN = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-
-# --- Helper Functions ---
-
-def print_header(message):
-    """Prints a formatted header."""
-    print(f"\n{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}  {message}{Colors.ENDC}")
-    print(f"{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
-
-def print_status(message, success=True, details=""):
-    """Prints a status message with a checkmark or cross."""
-    if success:
-        print(f"  {Colors.OKGREEN}✅ {message}{Colors.ENDC}")
-    else:
-        print(f"  {Colors.FAIL}❌ {message}{Colors.ENDC}")
-    if details:
-        print(f"     {Colors.OKCYAN}{details}{Colors.ENDC}")
+from validate_config import Colors, print_header, print_status
 
 # --- Test Simulator Class ---
 

--- a/scripts/validate_config.py
+++ b/scripts/validate_config.py
@@ -50,18 +50,20 @@ class Colors:
 
 # --- Helper Functions ---
 
-def print_header(message):
+def print_header(message: str) -> None:
     """Prints a formatted header."""
     print(f"\n{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
     print(f"{Colors.HEADER}{Colors.BOLD}  {message}{Colors.ENDC}")
     print(f"{Colors.HEADER}{Colors.BOLD}================================================={Colors.ENDC}")
 
-def print_status(message, success=True):
+def print_status(message: str, success: bool = True, details: str = "") -> None:
     """Prints a status message with a checkmark or cross."""
     if success:
         print(f"  {Colors.OKGREEN}✅ {message}{Colors.ENDC}")
     else:
         print(f"  {Colors.FAIL}❌ {message}{Colors.ENDC}")
+    if details:
+        print(f"     {Colors.OKCYAN}{details}{Colors.ENDC}")
 
 def print_error(message, details=""):
     """Prints a formatted error message."""

--- a/tests/test_output_helpers.py
+++ b/tests/test_output_helpers.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from validate_config import Colors, print_header, print_status
+
+
+def test_colors_okgreen() -> None:
+    assert Colors.OKGREEN == "\033[92m"
+
+
+def test_print_status_with_details(capfd: pytest.CaptureFixture[str]) -> None:
+    print_status("message", success=True, details="extra")
+    out, _ = capfd.readouterr()
+    assert "message" in out
+    assert "extra" in out
+    assert "✅" in out
+
+
+def test_print_header_outputs(capfd: pytest.CaptureFixture[str]) -> None:
+    print_header("Title")
+    out, _ = capfd.readouterr()
+    assert "Title" in out
+    assert Colors.HEADER in out


### PR DESCRIPTION
## Summary
- centralize color and console helpers in `validate_config`
- reuse shared helpers across scripts
- add tests for helper output formatting

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af199286148322925422728df4f351