### PR TITLE
docs: add predictive intelligence rules for SPARC orchestrator

### DIFF
--- a/.roo/rules-sparc-orchestrator/predictive-intelligence.md
+++ b/.roo/rules-sparc-orchestrator/predictive-intelligence.md
@@ -1,0 +1,73 @@
+# Predictive Intelligence Protocols for SPARC Orchestrator
+
+## Pattern-Based Prediction Engine
+
+### Pattern Memory
+- **Primary File**: `project/<id>/control/prediction-state.json`
+- **Pattern Sources**: `memory-bank/systemPatterns.md`, historical workflow data
+- **Update Frequency**: After each major workflow event
+
+### Signal Processing
+- Aggregate cross-mode telemetry for trend recognition
+- Compute confidence score for each recognized pattern
+- Require min confidence 0.7 to trigger intervention
+
+### Prediction Record Template
+```json
+{
+  "pattern_id": "[unique-pattern-id]",
+  "signals": ["[signal-1]", "[signal-2]"],
+  "confidence": 0.0,
+  "predicted_issue": "[issue-type]",
+  "timestamp": "[ISO-8601]"
+}
+```
+
+## Predictive Intervention Actions
+
+### Intervention Trigger
+- When prediction confidence > 0.75
+- When predicted issue affects critical path or quality gates
+
+### Intervention Task Template
+```json
+{
+  "tool": "new_task",
+  "args": {
+    "mode": "[specialist-mode-from-capabilities.yaml]",
+    "objective": "[preventive-action-objective]",
+    "context": {
+      "prediction": "[pattern-id]",
+      "signals": ["[signal-1]", "[signal-2]"],
+      "business_context": "[why-this-matters]",
+      "technical_context": "[current-state-and-constraints]",
+      "success_criteria": "[measurable-outcome]"
+    },
+    "priority": "[calculated-priority]",
+    "inputs": "[artifacts-required]",
+    "acceptance_criteria": [
+      "[deliverable-1]",
+      "[deliverable-2]"
+    ],
+    "handoff_contract": "HANDOFF/V1"
+  }
+}
+```
+
+## Learning Integration
+
+### Feedback Capture
+- Log prediction outcomes in `memory-bank/predictionLog.md`
+- Update pattern confidence metrics with actual outcomes
+- Archive failed predictions for root cause analysis
+
+### Learning Record Template
+```json
+{
+  "pattern_id": "[pattern-id]",
+  "outcome": "[success|failure]",
+  "accuracy": 0.0,
+  "lesson_learned": "[what-we-learned]",
+  "action_taken": "[follow-up-steps]"
+}
+```


### PR DESCRIPTION
## Summary
- document pattern-based prediction engine for SPARC orchestrator
- specify predictive intervention task template
- integrate feedback capture and learning records

## Testing
- `pytest -q` *(fails: No module named 'yaml' and 'aiofiles')*

------
https://chatgpt.com/codex/tasks/task_e_68af3ced40608322be944fc2db584d46