### PR TITLE
[memory-bank] detect quality anomalies and alert workflow

### DIFF
--- a/tests/detect_quality_anomalies.test.js
+++ b/tests/detect_quality_anomalies.test.js
@@ -1,0 +1,62 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const LearningQualityControl = require('../memory-bank/lib/learning-quality-control');
+
+test('detectQualityAnomalies logs anomalies and updates control files', async () => {
+  const tmp = await fs.mkdtemp(path.join(os.tmpdir(), 'quality-'));
+  const dashboard = path.join(tmp, 'quality-dashboard.json');
+  const workflow = path.join(tmp, 'workflow-state.json');
+  await fs.writeFile(dashboard, '{}');
+  await fs.writeFile(workflow, '{}');
+  process.env.QUALITY_DASHBOARD_PATH = dashboard;
+  process.env.WORKFLOW_STATE_PATH = workflow;
+  const qc = new LearningQualityControl({ modeName: 'test' });
+  const prev = {
+    mode: 'test',
+    gate_type: 'general',
+    overall_score: 0.9,
+    passed: true,
+    check_count: 1,
+    learning_enhanced: false,
+    timestamp: new Date().toISOString()
+  };
+  qc.qualityMetrics.set('test_general', prev);
+  const metrics = {
+    gate_type: 'general',
+    overall_score: 0.7,
+    timestamp: new Date().toISOString()
+  };
+  const anomaly = await qc.detectQualityAnomalies(metrics);
+  assert.equal(anomaly, true);
+  const dash = JSON.parse(await fs.readFile(dashboard, 'utf8'));
+  assert.ok(Array.isArray(dash.predictive_quality_indicators));
+  const flow = JSON.parse(await fs.readFile(workflow, 'utf8'));
+  assert.ok(flow.tasks.find((t) => t.assignee === 'Quality Coordinator' && t.priority === 'high'));
+});
+
+test('detectQualityAnomalies returns false for minor deviations', async () => {
+  const qc = new LearningQualityControl({ modeName: 'test' });
+  qc.qualityMetrics.set('test_general', {
+    gate_type: 'general',
+    overall_score: 0.9,
+    timestamp: new Date().toISOString()
+  });
+  const result = await qc.detectQualityAnomalies({
+    gate_type: 'general',
+    overall_score: 0.85,
+    timestamp: new Date().toISOString()
+  });
+  assert.equal(result, false);
+});
+
+test('detectQualityAnomalies rejects invalid metrics', async () => {
+  const qc = new LearningQualityControl({ modeName: 'test' });
+  await assert.rejects(
+    () => qc.detectQualityAnomalies({ gate_type: 1, overall_score: 2 }),
+    /Invalid metrics input/
+  );
+});
+


### PR DESCRIPTION
## Summary
- add `QualityAnomalyError` and helpers for timeout-aware file I/O
- implement `detectQualityAnomalies` to compare metrics with history and flag >10% drops
- log anomalies to project control files and queue a high-priority coordinator task
- cover detection, non-anomaly, and invalid input cases with Node tests

## Testing
- `python scripts/validate_config.py sample-app` *(fails: Must contain a non-empty list under the 'agents' key)*
- `pytest -q`
- `npm run -s lint || npx eslint .` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test` *(fails: Could not read package.json)*
- `node --test`


------
https://chatgpt.com/codex/tasks/task_e_68b0ad9ffa548322842b99a151a68bca