### PR TITLE
[memory-bank] add retry and timeout for learning client

### DIFF
--- a/tests/learning_protocol_client.test.js
+++ b/tests/learning_protocol_client.test.js
@@ -12,6 +12,12 @@ async function setupClient() {
   await fs.cp(path.join(__dirname, '..', 'memory-bank'), path.join(tmp, 'memory-bank'), {
     recursive: true
   });
+  // stub pattern-storage to avoid heavy dependencies
+  const stub = `class Store {\n  async getRecommendedPatterns() { return []; }\n  async updatePatternStats() { return { metadata: { usage_statistics: {} } }; }\n}\nmodule.exports = Store;`;
+  await fs.writeFile(
+    path.join(tmp, 'memory-bank', 'lib', 'pattern-storage.js'),
+    stub
+  );
   const client = new LearningProtocolClient({ learningSystemPath: path.join(tmp, 'memory-bank') });
   return { client, tmp };
 }
@@ -23,5 +29,34 @@ test('logOutcome appends success and failure counts', async () => {
   const content = await fs.readFile(logFile, 'utf8');
   assert.match(content, /Successful Applications:/);
   assert.match(content, /Failed Applications:/);
+});
+
+test('getLearningGuidance retries before succeeding', async () => {
+  const { client } = await setupClient();
+  let calls = 0;
+  client.queryLearningSystem = async () => {
+    calls += 1;
+    if (calls < 3) throw new Error('temporary');
+    return { available: true, guidance: { recommendations: [], recommended_patterns: [] }, metadata: {} };
+  };
+  const res = await client.getLearningGuidance({}, 'unit');
+  assert.equal(calls, 3);
+  assert.equal(res.available, true);
+});
+
+test('getLearningGuidance throws LearningApiError after timeouts', async () => {
+  const { client } = await setupClient();
+  client.options.timeoutMs = 50;
+  let calls = 0;
+  client.queryLearningSystem = async () => {
+    calls += 1;
+    await new Promise(res => setTimeout(res, 100));
+    return { available: true, guidance: { recommendations: [], recommended_patterns: [] }, metadata: {} };
+  };
+  await assert.rejects(
+    () => client.getLearningGuidance({}, 'unit'),
+    err => err instanceof LearningProtocolClient.LearningApiError
+  );
+  assert.equal(calls, client.options.retries);
 });
 


### PR DESCRIPTION
## Summary
- add configurable timeout and exponential backoff to LearningProtocolClient
- pass timeout config through helpers and quality control, handling LearningApiError
- test retry and timeout behavior for learning client

## Testing
- `pytest -q`
- `ruff check .`
- `npm run -s lint || npx eslint .`
- `npm test` *(fails: package.json missing)*
- `node --test tests/learning_protocol_client.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68b0ea5a5aec8322962dd40fc11b2854